### PR TITLE
Hide tire type field and add service chart filtering

### DIFF
--- a/tracker/templates/tracker/dashboard.html
+++ b/tracker/templates/tracker/dashboard.html
@@ -329,11 +329,11 @@
                         <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                             <i class="fa fa-calendar me-1"></i>Period
                         </button>
-                        <ul class="dropdown-menu">
-                            <li><a class="dropdown-item" href="#">This Week</a></li>
-                            <li><a class="dropdown-item" href="#">This Month</a></li>
-                            <li><a class="dropdown-item" href="#">This Quarter</a></li>
-                            <li><a class="dropdown-item" href="#">This Year</a></li>
+                        <ul class="dropdown-menu" id="servicePeriodMenu">
+                            <li><a class="dropdown-item" href="#" data-period="week">This Week</a></li>
+                            <li><a class="dropdown-item" href="#" data-period="month">This Month</a></li>
+                            <li><a class="dropdown-item" href="#" data-period="quarter">This Quarter</a></li>
+                            <li><a class="dropdown-item" href="#" data-period="year">This Year</a></li>
                         </ul>
                     </div>
                 </div>
@@ -643,11 +643,12 @@
     });
 
     // Service Distribution Chart (Bar Chart)
+    var serviceChart = null;
     try{
       var serviceCanvas = document.getElementById('serviceDistributionChart');
       if (serviceCanvas) {
         var ctx = serviceCanvas.getContext('2d');
-        var serviceChart = new Chart(ctx, {
+        serviceChart = new Chart(ctx, {
           type: 'bar',
           data: {
             labels: ['Sales', 'Service', 'Inquiry'],
@@ -707,6 +708,42 @@
           }
         });
       }
+
+      // Period selection handling for Service Distribution
+      (function(){
+        var menu = document.getElementById('servicePeriodMenu');
+        if(!menu) return;
+        menu.addEventListener('click', function(e){
+          var link = e.target.closest('.dropdown-item[data-period]');
+          if(!link) return;
+          e.preventDefault();
+          var period = link.getAttribute('data-period');
+          fetchAndUpdateServiceChart(period);
+        });
+
+        async function fetchAndUpdateServiceChart(period){
+          try{
+            var params = new URLSearchParams();
+            if(period) params.set('period', period);
+            var urlParams = new URLSearchParams(window.location.search);
+            var branch = urlParams.get('branch');
+            if(branch) params.set('branch', branch);
+            var res = await fetch('/api/service-distribution/?' + params.toString(), { headers: { 'Accept': 'application/json' }});
+            var json = await res.json();
+            if(json && json.success && serviceChart){
+              if(Array.isArray(json.values)){
+                serviceChart.data.datasets[0].data = json.values;
+              }
+              if(json.label){
+                serviceChart.data.datasets[0].label = json.label;
+              }
+              serviceChart.update();
+            }
+          }catch(err){
+            console.error('Failed to update service distribution chart:', err);
+          }
+        }
+      })();
     }catch(e){
       console.error('Error creating service distribution chart:', e);
     }

--- a/tracker/templates/tracker/partials/customer_registration_form.html
+++ b/tracker/templates/tracker/partials/customer_registration_form.html
@@ -200,12 +200,8 @@
             <label class="form-label">Quantity</label>
             <input name="quantity" class="form-control">
           </div>
-          <div class="col-md-8">
-            <label class="form-label">Tire type</label>
-            <select name="tire_type" class="form-select">
-              <option value="">Select condition</option>
-              <option value="New">New</option>
-            </select>
+          <div class="col-md-8 d-none">
+            <input type="hidden" name="tire_type" value="New">
           </div>
 
           <!-- Tire Service Add-ons -->

--- a/tracker/templates/tracker/partials/order_form_sections.html
+++ b/tracker/templates/tracker/partials/order_form_sections.html
@@ -78,8 +78,7 @@
                 {% endif %}
             </div>
             
-            <div class="col-md-8">
-                <label class="form-label">{{ form.tire_type.label }}</label>
+            <div class="col-md-8 d-none">
                 {{ form.tire_type }}
                 {% if form.tire_type.errors %}
                 <div class="text-danger f-12">{{ form.tire_type.errors|striptags }}</div>

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -124,4 +124,5 @@ urlpatterns = [
     path("api/notification/summary/", views.api_notifications_summary, name="api_notifications_summary_singular"),
     path("api/notification/summary", views.api_notifications_summary),
     path("api/customers/check-duplicate/", views.api_check_customer_duplicate, name="api_check_customer_duplicate"),
+    path("api/service-distribution/", views.api_service_distribution, name="api_service_distribution"),
 ]


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user requested several UI improvements:
1. Hide the tire type selection field since the system only deals with "New" tires, but still submit the value automatically
2. Fix the save customer button functionality that was not working properly
3. Implement dynamic filtering for service distribution charts to handle users from different areas

## Code changes

### Form Updates
- **Hidden tire type field**: Modified `customer_registration_form.html` and `order_form_sections.html` to hide the tire type dropdown using `d-none` class and set a hidden input with value "New"
- **Fixed save customer functionality**: Added proper handling for the "save_only" flag in the customer registration view to allow saving customer info from any step

### Dashboard Enhancements
- **Service distribution chart filtering**: Added interactive period selection (week, month, quarter, year) for the service distribution chart
- **New API endpoint**: Created `/api/service-distribution/` endpoint to fetch filtered chart data based on selected time periods
- **Chart state management**: Improved chart initialization and update logic with proper error handling

### Technical Improvements
- Added proper event handling for dropdown menu interactions
- Implemented async data fetching for chart updates
- Added branch-aware filtering for service distribution data
- Enhanced error handling and user feedback

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7e3af695a06342a1b5f3980a0cfd0655/zenith-hub)

👀 [Preview Link](https://7e3af695a06342a1b5f3980a0cfd0655-zenith-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7e3af695a06342a1b5f3980a0cfd0655</projectId>-->
<!--<branchName>zenith-hub</branchName>-->